### PR TITLE
Show information and error message for unlock action

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,9 +32,10 @@ export function activate(context: vscode.ExtensionContext) {
         if (passphrase === undefined) { return; }
         try {
             await keyStatusManager.unlockCurrentKey(passphrase);
+            vscode.window.showInformationMessage('Key unlocked.');
         } catch (err) {
             if (err instanceof Error) {
-                vscode.window.showInformationMessage(`Failed to unlock: ${err.message}`);
+                vscode.window.showErrorMessage(`Failed to unlock: ${err.message}`);
             }
         }
     });

--- a/src/indicator/gpg.ts
+++ b/src/indicator/gpg.ts
@@ -100,9 +100,16 @@ export async function unlockByKeyId(keyId: string, passphrase: string): Promise<
             `send "y\\r"\n` +
             `expect "*Enter passphrase:*"\n` +
             `send "${passphrase}\\r"\n` +
-            `wait\n`;
+            `set result [lindex [wait] 3]\n` +
+            `exit $result\n`;
 
         await process.textSpawn('expect', [], expectCommand);
+    } catch(err) {
+        if (err instanceof process.ProcessError) {
+            throw new Error('the given passphrase may be wrong');
+        } else {
+            throw err;
+        }
     } finally {
         signature?.dispose();
         document?.dispose();

--- a/src/indicator/process.ts
+++ b/src/indicator/process.ts
@@ -1,7 +1,5 @@
 
 import * as child from 'child_process';
-import * as fs from 'fs';
-import * as os from 'os';
 
 
 export function sleep(ms: number): Promise<void> {

--- a/src/indicator/process.ts
+++ b/src/indicator/process.ts
@@ -8,12 +8,20 @@ export function sleep(ms: number): Promise<void> {
     });
 }
 
+export class ProcessError extends Error {
+    constructor(message: string) {
+        super(message);
+    }
+}
+
 /**
  * Run specified command, with given input and return output(promise) in string
  *
  * @param command executable name
  * @param args options and arguments, executable name is not included
  * @param input stdin
+ * @throws {ProcessError} if the process returns non-zero
+ * @throws Other errors may be throws by underline Node runtime
  * @returns The promise which resolve the stdout. Rejects if fail to run command or command returns not zero value.
  */
 export function textSpawn(command: string, args: Array<string>, input: string): Promise<string> {
@@ -40,7 +48,7 @@ export function textSpawn(command: string, args: Array<string>, input: string): 
         proc.on('error', reject);
         proc.on('close', (code) => {
             if (code !== 0) {
-                reject(new Error(`Command ${command} failed, return code: ${code}, stderr: ${error_message}`));
+                reject(new ProcessError(`Command ${command} failed, return code: ${code}, stderr: ${error_message}`));
             }
             resolve(output);
         });


### PR DESCRIPTION
Check `expect` command status and show a message to add more feedback to key-unlock action.