### PR TITLE
Read global Git config settings if locals are not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ You can also also unlock the key by clicking the status bar element. :D
 
 ## Features
 
-This extension will show the status of GPG signing key in status bar if
+This extension will show the status of GPG signing key in status bar if your local project folder `.git` or any other default `.gitconfig` configuration file (e.g. `~/.gitconfig`):
 
-- The project folder has set `commit.gpgSign` as `true` for git, and
-- The project folder has set `user.signingKey` with GPG key ID for git
+- has set `commit.gpgSign` as `true` for git, and
+- has set `user.signingKey` with GPG key ID for git
 
-If the above condition are satisfied, there will be an indicator for your current
+If the above conditions are both satisfied, there will be an indicator for your current
 signing key, together with a cute icon to tell whether the key is unlocked or not.
 
 When you click the indicator, you will be prompted for passphrase to unlock the key.

--- a/src/indicator/git.ts
+++ b/src/indicator/git.ts
@@ -15,12 +15,12 @@ function fromGitBoolean(data: string): boolean {
     data = data.toLowerCase();
     let result: boolean = false;
     switch (data) {
-        case 'true':
-        case 'yes':
-        case 'on':
-        case '1':
-            result = true;
-            break;
+    case 'true':
+    case 'yes':
+    case 'on':
+    case '1':
+        result = true;
+        break;
     }
     return result;
 }

--- a/src/indicator/git.ts
+++ b/src/indicator/git.ts
@@ -15,12 +15,12 @@ function fromGitBoolean(data: string): boolean {
     data = data.toLowerCase();
     let result: boolean = false;
     switch (data) {
-    case 'true':
-    case 'yes':
-    case 'on':
-    case '1':
-        result = true;
-        break;
+        case 'true':
+        case 'yes':
+        case 'on':
+        case '1':
+            result = true;
+            break;
     }
     return result;
 }
@@ -28,7 +28,7 @@ function fromGitBoolean(data: string): boolean {
 export async function getSigningKey(project: string): Promise<string> {
     try {
         // see: https://git-scm.com/docs/git-config#Documentation/git-config.txt-usersigningKey
-        const { stdout } = await exec('git config --local --get user.signingKey', {
+        const { stdout } = await exec('git config --get user.signingKey', {
             cwd: project
         });
 
@@ -43,7 +43,7 @@ export async function getSigningKey(project: string): Promise<string> {
 export async function isSigningActivated(project: string): Promise<boolean> {
     try {
         // see: https://git-scm.com/docs/git-config#Documentation/git-config.txt-commitgpgSign
-        const { stdout } = await exec('git config --local --get commit.gpgSign', {
+        const { stdout } = await exec('git config --get commit.gpgSign', {
             cwd: project
         });
 


### PR DESCRIPTION
As per issue description on #4 - This PR adds this capability to the code as other users have their GPG settings enabled by default to all their projects they're working on.

Documentaton also updated to reflect this small change