### PR TITLE
Add VS Code ignore record for dependency package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,8 @@
 !README.md
 !CHANGELOG.md
 !images/icon-color.png
+
+# Add each dependency library manually.
+# This is a light weight solution to release without bundle tool.
+# see: https://code.visualstudio.com/api/working-with-extensions/bundling-extension
+!node_modules/lookpath


### PR DESCRIPTION
Version 0.3.3 include first dependent NPM package and we forget to handle this part in packaging procedure.

Since there is only one dependency now, I don't want to include bundle tool to the packaging procedure.
Instead, I just add the dependency library to white list of VS Code ignore file.