### PR TITLE
Add workflow for basic lint job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: check-code-quality
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  check:
+    runs-on: ubuntu-20.04
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 12.x
+
+      - name: Install dependent packages
+        run: npm install
+
+      - name: Run lint job
+        run: npm run lint


### PR DESCRIPTION
Use runner hosted by GitHub to check code quality automatically.

Fix #11 