### PR TITLE
Updated actionEvents to work with remote SSH + docker containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 	],
 	"icon": "images/icon-color.png",
 	"activationEvents": [
-		"workspaceContains:/.git"
+		"workspaceContains:/.git",
+		"onCommand:gpgIndicator.unlockCurrentKey"
 	],
 	"main": "./out/extension.js",
 	"contributes": {


### PR DESCRIPTION
Hi all,

This PR contains a minor fix for the "unlockCurrentKey is not a command" error message that I was receiving when using this extension with docker containers.

According to the documentation, you must open the git folder _first_ before using this extension. While this works fine, I am actually using the Docker extension to attach to containers onto the remote SSH server. So, while I may not be in the project folder from the first connection, I am indeed in the project folder within the attached docker container.

I believe this fix shouldn't break anything if you're just using the Remote SSH extension to connect to a remote server; however, if you're attaching to a docker container on the remote SSH server, this should resolve the issue of VS Code not understanding the `unlockCurrentKey` command.

This fixed the problem for me, so just wanted to propose the same change to the official repo.

Let me know if there are any questions. Thanks so much for taking the time on this extension.