### PR TITLE
Only trigger unlock command when the key is locked

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -271,6 +271,12 @@ class KeyStatusManager {
             throw new Error('No key for current folder');
         }
 
+        await this.syncStatus();
+        if (await gpg.isKeyUnlocked(theKey.keygrip)) {
+            this.#logger.log(`Key is already unlocked, skip unlock request`);
+            return;
+        }
+
         this.#logger.log(`Try to unlock current key: ${theKey.fingerprint}`);
         await gpg.unlockByKeyId(theKey.fingerprint, passphrase);
         await this.syncStatus();


### PR DESCRIPTION
Currently the unlock command will failed, because the behavior of `gpg` command is slightly different when the key is already unlocked. The `expect` process fails because the `gpg` don't ask for passphrase in this case.

Add new check just before the unlock action to avoid error prompt for user, and leave a debug message in output panel for the skip behavior.