### PR TITLE
Update gpg command to get key info in machine-readable format 

### DIFF
--- a/src/indicator/gpg.ts
+++ b/src/indicator/gpg.ts
@@ -55,15 +55,9 @@ export async function isKeyUnlocked(keygrip: string): Promise<boolean> {
 }
 
 export async function isKeyIdUnlocked(keyId: string): Promise<boolean> {
-    // --fingerprint flag is give twice to get fingerprint of subkey
-    let keyInfoRaw: string = await process.textSpawn('gpg', ['--fingerprint', '--fingerprint', '--with-keygrip'], '');
-    let infos = parseGpgKey(keyInfoRaw);
-
-    for (let info of infos) {
-        // GPG signing key is usually given as shorter ID
-        if (info.fingerprint.includes(keyId)) {
-            return isKeyUnlocked(info.keygrip);
-        }
+    const keyInfo = await getKeyInfo(keyId);
+    if (keyInfo) {
+        return isKeyUnlocked(keyInfo.keygrip);
     }
 
     throw new Error(`Can not find key with ID: ${keyId}`);

--- a/src/indicator/gpg.ts
+++ b/src/indicator/gpg.ts
@@ -12,20 +12,22 @@ export interface GpgKeyInfo {
 /**
  * Parse lots GPG key information from gpg command
  *
- * @param rawText - output string from gpg --fingerprint --fingerprint --with-keygrip
+ * @param rawText - output string from gpg --fingerprint --fingerprint --with-keygrip --with-colon
  */
 function parseGpgKey(rawText: string): Array<GpgKeyInfo> {
-    let pattern: RegExp = /(pub|sub)\s+\w+.*\[(.)*\]\n((?:\s*\w+)*)\n\s+Keygrip\s=\s(\w+)/g;
-    // group 1: pub or sub, 2: ability (E S C A), 3: fingerprint with spaces 4. keygrip
+    /**
+     * group 1: pub or sub, 2: ability (E S C A), 3: fingerprint 4. keygrip
+     * For more information, see https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS
+     */
+    let pattern: RegExp = /(pub|sub).*:([escaD?]+)\w*:.*\n.*fpr.*:(\w*):\n.*grp.*:(\w*):/g;
 
     let infos: Array<GpgKeyInfo> = [];
     let matched: RegExpExecArray | null;
     while ((matched = pattern.exec(rawText)) !== null) {
-        let fingerprint = matched[3].replace(/\s+/g, '');
         let info = {
             type: matched[1],
             capabilities: matched[2],
-            fingerprint: fingerprint,
+            fingerprint: matched[3],
             keygrip: matched[4],
         };
         infos.push(info);
@@ -72,8 +74,12 @@ export async function isKeyIdUnlocked(keyId: string): Promise<boolean> {
  * @returns key information
  */
 export async function getKeyInfo(keyId: string): Promise<GpgKeyInfo> {
-    // --fingerprint flag is give twice to get fingerprint of subkey
-    let keyInfoRaw: string = await process.textSpawn('gpg', ['--fingerprint', '--fingerprint', '--with-keygrip'], '');
+    /**
+     * --fingerprint flag is given twice to get fingerprint of subkey
+     * --with-colon flag is given to get the key information in a more machine-readable manner
+     * For more information, see https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS
+     */
+    let keyInfoRaw: string = await process.textSpawn('gpg', ['--fingerprint', '--fingerprint', '--with-keygrip', '--with-colon'], '');
     let infos = parseGpgKey(keyInfoRaw);
 
     for (let info of infos) {
@@ -129,4 +135,3 @@ export async function unlockByKeyId(keyId: string, passphrase: string): Promise<
     // gpg can signed the document even if the document is empty
 
 }
-


### PR DESCRIPTION
This PR fixes an issue I had where the output from `gpg --fingerprint --fingerprint --with-keygrip` command did not match the default output on my machine. I believe this will fix #20 as well.

### The Problem
I use a VM as my development environment so I use vscode's `Remote SSH` feature.
After installing this extension, I did not get a status item at the bottom left corner of vscode's window.

I did a little digging and found that the output expected from the gpg command that gets the key information differs on my machine because the extension could get my key information but while parsing it the regex did not match anything. This happened because I had a custom config file on my home directory (`~/.gnupg/gpg.conf`) that made the keyid-format to be in the form of `0xlong` and thus made the regex not compatible, even though my use case is still valid.

### Solution
While searching for a more _standardized_ way of getting the key information, I stumbled upon [this](https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS) documentation file from GnuPG.

At a glance, it explains the "colon-seperated format" which makes the output more stable and parsable.
So I added the `--with-colon` option to the command and changed the regex accordingly. This fixed my issue and I had no other problems unlocking my key.

I tested this with two different machines using two different versions of gpg and it seems to work stable.