### PR TITLE
fix response is not of given type

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -295,6 +295,9 @@ class KeyStatusManager {
         }
 
         this.#logger.info(`Try to unlock current key: ${theKey.fingerprint}`);
+        // Escape percent character.
+        // https://www.gnupg.org/documentation/manuals/assuan/Client-requests.html#Client-requests
+        passphrase.replace(/%/g,'%25');
         await gpg.unlockByKey(this.#logger, theKey.keygrip, passphrase);
         await this.syncStatus();
     }


### PR DESCRIPTION
- Fix error when a percent character is in the passphrase

Typescript/Javascript is not my strongest language so I'm not sure if this is the best way to fix #30, but it works.