### PR TITLE
Support exclamation mark within signing key ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -290,9 +290,9 @@
 			"dev": true
 		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -348,7 +348,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
 		},
 		"cross-spawn": {
@@ -904,9 +904,9 @@
 			}
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"

--- a/src/indicator/git.ts
+++ b/src/indicator/git.ts
@@ -34,6 +34,9 @@ export async function getSigningKey(project: string): Promise<string> {
 
         let output: string = stdout;
         output = rstrip(output);
+
+        // Some Git/GPG context allow appending exclamation mark to specify exact key match.
+        output = output.replace('!', '');
         return output;
     } catch (error) {
         throw new Error('Fail to get signing key');


### PR DESCRIPTION
The trailing exclamation mark in key ID is allowed in some context, e.g GPG, Git config,
for specifying that the exact key is require for some operation.

See:

- <https://www.gnupg.org/documentation/manuals/gnupg/Specify-a-User-ID.html>
- <https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work>

Fix #42 