### PR TITLE
fix: EPIPE error

### DIFF
--- a/src/indicator/process.ts
+++ b/src/indicator/process.ts
@@ -29,9 +29,11 @@ export function textSpawn(command: string, args: Array<string>, input: string): 
     return new Promise((resolve, reject) => {
         let proc = child.spawn(command, args);
 
-        proc.stdin.on('error', reject);
-        proc.stdin.write(input, 'utf8');
-        proc.stdin.end();
+        if (input) {
+            proc.stdin.on('error', reject);
+            proc.stdin.write(input, 'utf8');
+            proc.stdin.end();
+        }
 
         // setEncoding to force 'data' event returns string
         // see: https://nodejs.org/api/stream.html#stream_readable_setencoding_encoding


### PR DESCRIPTION
This PR makes `src/indicator/process.ts` only try to write to a spawned process if there is some truthy input for it.

Fixes: #38 (at least for me, having the issue described there) 