### PR TITLE
Correct locker behavior for context interface

### DIFF
--- a/src/indicator/locker.spec.ts
+++ b/src/indicator/locker.spec.ts
@@ -1,0 +1,31 @@
+import * as assert from 'assert';
+
+import * as locker from './locker';
+
+describe('locker', () => {
+
+    const sleep = (ms: number): Promise<void> => {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    };
+
+    describe('Mutex', () => {
+        it('should provide exclusive execution', async () => {
+            const mutex = new locker.Mutex(0);
+
+            let counter = 0;
+            const buildJob = (n: number) => {
+                return mutex.with(async () => {
+                    const next = counter + 1;
+                    await sleep(0); // provide a chance to switch context.
+                    counter = next;
+                });
+            };
+            const jobCount = 32;
+            const jobs = [...Array(jobCount).keys()].map(buildJob);
+
+            await Promise.all(jobs);
+
+            assert.strictEqual(counter, jobCount);
+        });
+    });
+});

--- a/src/indicator/locker.ts
+++ b/src/indicator/locker.ts
@@ -1,29 +1,38 @@
+/**
+ * A simple mutex locker.
+ * 
+ * Provide usage in "lock/unlock" style and "with" style.
+ */
 export class Mutex {
     private isOn: boolean;
-    constructor() {
+    constructor(private backoffMs: number = 500) {
         this.isOn = false;
     }
 
+    /** with blocking wait the lock before run job, and unlock before return. */
     async with(job: () => Promise<void>) {
         await this.lock();
         try {
             await job();
         } finally {
+            // unlock in "finally" to ensure cleanup for potential exception.
             this.unlock();
         }
     }
 
+    /** lock the mutex, block until the mutex is unlocked. */
     async lock() {
+        // just check the value, since that JS runtime is single thread.
         while (true) {
             if (!this.isOn) {
                 break;
             }
-            await sleep(500);
+            await sleep(this.backoffMs);
         }
         this.isOn = true;
     }
 
-
+    /** unlock the mutex, allow other to lock. */
     async unlock() {
         this.isOn = false;
     }

--- a/src/indicator/locker.ts
+++ b/src/indicator/locker.ts
@@ -16,7 +16,7 @@ export class Mutex {
             await job();
         } finally {
             // unlock in "finally" to ensure cleanup for potential exception.
-            this.unlock();
+            await this.unlock();
         }
     }
 


### PR DESCRIPTION
The "with" context interface of `Mutex` does not block until we                                                                                  set the flag to false. This cause unnecessary waiting time for other                                                                           routines to acquire the lock.   