### PR TITLE
Support signing keys starting with 0x

### DIFF
--- a/src/adapter/git.ts
+++ b/src/adapter/git.ts
@@ -34,8 +34,8 @@ export async function getSigningKey(project: string): Promise<string> {
         let output: string = stdout;
         output = output.trimEnd();
 
-        // Some Git/GPG context allow appending exclamation mark to specify exact key match.
-        output = output.replace('!', '');
+        // Some Git/GPG context allow prepending '0x' to the key and appending exclamation mark to specify exact key match
+        output = output.replace('0x', '').replace('!', '');
         return output;
     } catch (error) {
         throw new Error('Fail to get signing key');

--- a/src/adapter/git.ts
+++ b/src/adapter/git.ts
@@ -34,7 +34,8 @@ export async function getSigningKey(project: string): Promise<string> {
         let output: string = stdout;
         output = output.trimEnd();
 
-        // Some Git/GPG context allow prepending '0x' to the key and appending exclamation mark to specify exact key match
+        // Some Git/GPG contexts allow prepending the key with '0x' and appending an exclamation mark to specify exact key match.
+        // see: https://www.gnupg.org/documentation/manuals/gnupg/Specify-a-User-ID.html
         output = output.replace('0x', '').replace('!', '');
         return output;
     } catch (error) {


### PR DESCRIPTION
I recently realized I didn't have the indicator in my editor so I checked the extension output and saw that I got this warning:

`[WARN] Can not find key information for folder: <path-to-my-current-folder>`

After a little bit of digging I remembered we use `--with-colon` to make the gpg output more machine-readable so key ids in the output of `--with-colon` does not have `0x` but if a user sets their `user.signingKey` in the format `0xABCDEF` (`--keyid-format 0xshort|0xlong`) it would not match anything.

So I just chained another replace to strip that out. In all honesty I just changed the extension's code directly and saw that it worked so I did not really test it any further. I can add a test case if it's requested/required.