### PR TITLE
Fix problem that extension hangs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,7 +95,9 @@ class MessageEventReceiver implements core.EventReceiver {
             }
         })();
 
-        await vscode.window.showInformationMessage(message);
+        vscode.window.showInformationMessage(message);
+        // Notice that we can not await on result promise, since that
+        // extension may hang if the message is never dismissed.
     }
 }
 


### PR DESCRIPTION
A bug that introduced in v0.7.4 after refactoring.

Info box promise never resolved if the message is never dismissed.
For output-only info box, we should not wait for the promise to be resolved.