### PR TITLE
Should return early when operation fail

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -155,6 +155,7 @@ export async function activate(context: vscode.ExtensionContext) {
             if (err instanceof Error) {
                 vscode.window.showErrorMessage(vscode.l10n.t(m['keyUnlockFailedWithId'], err.message));
             }
+            return;
         }
 
         if (keyStatusManager.enablePassphraseCache) {


### PR DESCRIPTION
Currently there is a incorrect `Key unlocked` info box even when the unlock
process actually fails, e.g. using a wrong passphrase.

Fix the misleading and inappropriate info box.